### PR TITLE
Update config.h

### DIFF
--- a/src/knx/config.h
+++ b/src/knx/config.h
@@ -57,7 +57,8 @@
 #endif
 
 // KNX Data Secure Options
-#define USE_DATASECURE
+// Define via a compiler -D flag if required
+// #define USE_DATASECURE
 
 #endif
 


### PR DESCRIPTION
Having USE_DATASECURE defined by default breaks installations that do not use KNX Secure. 

Reason
Due the the way "bool BauSystemBCoupler::configured()" is implemented, "knx.configured()" will always return "false"

Proposed Solution
Let the user define USE_DATASECURE via compiler flags when required.